### PR TITLE
Marking SQL Spatial Types Functions

### DIFF
--- a/content/reference/sql/sql-support/data-description.md
+++ b/content/reference/sql/sql-support/data-description.md
@@ -39,9 +39,9 @@ title: Data Description
 | `ENUM`               | ✅        |                                 |
 | `SET`                | ✅        |                                 |
 | `GEOMETRY`           | ❌        |                                 |
-| `POINT`              | ❌        |                                 |
-| `LINESTRING`         | ❌        |                                 |
-| `POLYGON`            | ❌        |                                 |
+| `POINT`              | ✅        |                                 |
+| `LINESTRING`         | ✅        |                                 |
+| `POLYGON`            | ✅        |                                 |
 | `MULTIPOINT`         | ❌        |                                 |
 | `MULTILINESTRING`    | ❌        |                                 |
 | `MULTIPOLYGON`       | ❌        |                                 |

--- a/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -54,7 +54,7 @@ title: "Expressions, Functions, and Operators"
 
 ## Functions and operators
 
-**Currently supporting 138 of 436 MySQL functions.**
+**Currently supporting 152 of 438 MySQL functions.**
 
 Most functions are simple to implement. If you need one that isn't implemented, [please file an issue](https://github.com/dolthub/dolt/issues). We can fulfill most requests for new functions within 24 hours.
 
@@ -275,7 +275,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `LOWER()`                         | ✅        |                                                                                                |
 | `LPAD()`                          | ✅        |                                                                                                |
 | `LTRIM()`                         | ✅        |                                                                                                |
-| `LineString()`                    | ❌        |                                                                                                |
+| `LineString()`                    | ✅        |                                                                                                |
 | `MAKEDATE()`                      | ❌        |                                                                                                |
 | `MAKETIME()`                      | ❌        |                                                                                                |
 | `MAKE_SET()`                      | ❌        |                                                                                                |
@@ -329,8 +329,8 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `POWER()`                         | ✅        |                                                                                                |
 | `PS_CURRENT_THREAD_ID()`          | ❌        |                                                                                                |
 | `PS_THREAD_ID()`                  | ❌        |                                                                                                |
-| `Point()`                         | ❌        |                                                                                                |
-| `Polygon()`                       | ❌        |                                                                                                |
+| `Point()`                         | ✅        |                                                                                                |
+| `Polygon()`                       | ✅        |                                                                                                |
 | `QUARTER()`                       | ❌        |                                                                                                |
 | `QUOTE()`                         | ❌        |                                                                                                |
 | `RADIANS()`                       | ✅        |                                                                                                |
@@ -379,9 +379,11 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `STRCMP()`                        | ❌        |                                                                                                |
 | `STR_TO_DATE()`                   | ❌        |                                                                                                |
 | `ST_Area()`                       | ❌        |                                                                                                |
-| `ST_AsBinary()`                   | ❌        |                                                                                                |
-| `ST_AsGeoJSON()`                  | ❌        |                                                                                                |
-| `ST_AsText()`                     | ❌        |                                                                                                |
+| `ST_AsBinary()`                   | ✅        |                                                                                                |
+| `ST_AsGeoJSON()`                  | ✅        |                                                                                                |
+| `ST_AsText()`                     | ✅        |                                                                                                |
+| `ST_AsWKB()`                      | ✅        |                                                                                                |
+| `ST_AsWKT()`                      | ✅        |                                                                                                |
 | `ST_Buffer()`                     | ❌        |                                                                                                |
 | `ST_Buffer_Strategy()`            | ❌        |                                                                                                |
 | `ST_Centroid()`                   | ❌        |                                                                                                |
@@ -389,7 +391,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_ConvexHull()`                 | ❌        |                                                                                                |
 | `ST_Crosses()`                    | ❌        |                                                                                                |
 | `ST_Difference()`                 | ❌        |                                                                                                |
-| `ST_Dimension()`                  | ❌        |                                                                                                |
+| `ST_Dimension()`                  | ✅        |                                                                                                |
 | `ST_Disjoint()`                   | ❌        |                                                                                                |
 | `ST_Distance()`                   | ❌        |                                                                                                |
 | `ST_Distance_Sphere()`            | ❌        |                                                                                                |
@@ -400,9 +402,9 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_GeoHash()`                    | ❌        |                                                                                                |
 | `ST_GeomCollFromText()`           | ❌        |                                                                                                |
 | `ST_GeomCollFromWKB()`            | ❌        |                                                                                                |
-| `ST_GeomFromGeoJSON()`            | ❌        |                                                                                                |
-| `ST_GeomFromText()`               | ❌        |                                                                                                |
-| `ST_GeomFromWKB()`                | ❌        |                                                                                                |
+| `ST_GeomFromGeoJSON()`            | ✅        |                                                                                                |
+| `ST_GeomFromText()`               | ✅        |                                                                                                |
+| `ST_GeomFromWKB()`                | ✅        |                                                                                                |
 | `ST_GeometryN()`                  | ❌        |                                                                                                |
 | `ST_GeometryType()`               | ❌        |                                                                                                |
 | `ST_InteriorRingN()`              | ❌        |                                                                                                |
@@ -413,12 +415,12 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_IsSimple()`                   | ❌        |                                                                                                |
 | `ST_IsValid()`                    | ❌        |                                                                                                |
 | `ST_LatFromGeoHash()`             | ❌        |                                                                                                |
-| `ST_Latitude()`                   | ❌        |                                                                                                |
+| `ST_Latitude()`                   | ✅        |                                                                                                |
 | `ST_Length()`                     | ❌        |                                                                                                |
-| `ST_LineFromText()`               | ❌        |                                                                                                |
-| `ST_LineFromWKB()`                | ❌        |                                                                                                |
+| `ST_LineFromText()`               | ✅        |                                                                                                |
+| `ST_LineFromWKB()`                | ✅        |                                                                                                |
 | `ST_LongFromGeoHash()`            | ❌        |                                                                                                |
-| `ST_Longitude()`                  | ❌        |                                                                                                |
+| `ST_Longitude()`                  | ✅        |                                                                                                |
 | `ST_MLineFromText()`              | ❌        |                                                                                                |
 | `ST_MLineFromWKB()`               | ❌        |                                                                                                |
 | `ST_MPointFromText()`             | ❌        |                                                                                                |
@@ -431,23 +433,23 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_NumPoints()`                  | ❌        |                                                                                                |
 | `ST_Overlaps()`                   | ❌        |                                                                                                |
 | `ST_PointFromGeoHash()`           | ❌        |                                                                                                |
-| `ST_PointFromText()`              | ❌        |                                                                                                |
-| `ST_PointFromWKB()`               | ❌        |                                                                                                |
+| `ST_PointFromText()`              | ✅        |                                                                                                |
+| `ST_PointFromWKB()`               | ✅        |                                                                                                |
 | `ST_PointN()`                     | ❌        |                                                                                                |
 | `ST_PolyFromText()`               | ❌        |                                                                                                |
 | `ST_PolyFromWKB()`                | ❌        |                                                                                                |
-| `ST_SRID()`                       | ❌        |                                                                                                |
+| `ST_SRID()`                       | ✅        |                                                                                                |
 | `ST_Simplify()`                   | ❌        |                                                                                                |
 | `ST_StartPoint()`                 | ❌        |                                                                                                |
-| `ST_SwapXY()`                     | ❌        |                                                                                                |
+| `ST_SwapXY()`                     | ✅        |                                                                                                |
 | `ST_SymDifference()`              | ❌        |                                                                                                |
 | `ST_Touches()`                    | ❌        |                                                                                                |
 | `ST_Transform()`                  | ❌        |                                                                                                |
 | `ST_Union()`                      | ❌        |                                                                                                |
 | `ST_Validate()`                   | ❌        |                                                                                                |
 | `ST_Within()`                     | ❌        |                                                                                                |
-| `ST_X()`                          | ❌        |                                                                                                |
-| `ST_Y()`                          | ❌        |                                                                                                |
+| `ST_X()`                          | ✅        |                                                                                                |
+| `ST_Y()`                          | ✅        |                                                                                                |
 | `SUBDATE()`                       | ❌        |                                                                                                |
 | `SUBSTR()`                        | ✅        |                                                                                                |
 | `SUBSTRING()`                     | ✅        |                                                                                                |


### PR DESCRIPTION
Now Implemented:
 1. point
 2. linestring
 3. polygon
 4. st_geomfromwkb
 5. st_geomfromtext
 6. st_pointfromtext
 7. st_pointfromwkb
 8. st_linefromtext
 9. st_linefromwkb
 10. st_polyfromtext
 11. st_polyfromwkb
 12. st_asgeojson
 13. st_geomfromgeojson
 14. st_asbinary
 15. st_aswkb
 16. st_aswkt
 17. st_astext
 18. st_srid
 19. st_dimension
 20. st_longitude
 21. st_latitude
 22. st_swapxy
 23. st_x
 24. st_y