### PR TITLE
Record that indexes cannot be created on TEXT and BLOB column types

### DIFF
--- a/content/reference/sql/sql-support/data-description.md
+++ b/content/reference/sql/sql-support/data-description.md
@@ -63,7 +63,7 @@ title: Data Description
 
 | Component            | Supported | Notes and limitations                                                                                   |
 | :------------------- | :-------- | :------------------------------------------------------------------------------------------------------ |
-| Indexes              | ✅        | Unsupported on TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, TINYBLOB, BLOB, MEDIUMBLOB and LONGBLOB data types |
+| Indexes              | 🟠        | Unsupported on TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, TINYBLOB, BLOB, MEDIUMBLOB and LONGBLOB data types |
 | Multi-column indexes | ✅        |                                                                                                         |
 | Full-text indexes    | ❌        |                                                                                                         |
 | Spatial indexes      | ❌        |                                                                                                         |

--- a/content/reference/sql/sql-support/data-description.md
+++ b/content/reference/sql/sql-support/data-description.md
@@ -61,12 +61,12 @@ title: Data Description
 
 ## Indexes
 
-| Component            | Supported | Notes and limitations |
-| :------------------- | :-------- | :-------------------- |
-| Indexes              | ✅        |                       |
-| Multi-column indexes | ✅        |                       |
-| Full-text indexes    | ❌        |                       |
-| Spatial indexes      | ❌        |                       |
+| Component            | Supported | Notes and limitations                                                                                   |
+| :------------------- | :-------- | :------------------------------------------------------------------------------------------------------ |
+| Indexes              | ✅        | Unsupported on TINYTEXT, TEXT, MEDIUMTEXT, LONGTEXT, TINYBLOB, BLOB, MEDIUMBLOB and LONGBLOB data types |
+| Multi-column indexes | ✅        |                                                                                                         |
+| Full-text indexes    | ❌        |                                                                                                         |
+| Spatial indexes      | ❌        |                                                                                                         |
 
 ## Schema
 


### PR DESCRIPTION
See https://github.com/dolthub/dolt/issues/3974 for details.