### PR TITLE
docs(version-control): update dolt_log example

### DIFF
--- a/content/reference/sql/version-control/dolt-system-tables.md
+++ b/content/reference/sql/version-control/dolt-system-tables.md
@@ -946,7 +946,7 @@ The following query shows the commits reachable from the current checked out hea
 SELECT *
 FROM dolt_log
 WHERE committer = "bheni" and date > "2019-04-01"
-ORDER BY "date";
+ORDER BY date;
 ```
 
 ```text


### PR DESCRIPTION
Use `date` as a column reference instead of `"date"` as a string.