### PR TITLE
Update dolt merge docs

### DIFF
--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -1106,7 +1106,7 @@ Perform the merge and stop just before creating a merge commit. Note this will n
 Use an auto-generated commit message when creating a merge commit. The default for interactive CLI sessions is to open an editor.
 
 `--author`:
-Specify an explicit author using the standard A U Thor `<author@example.com>` format.
+Specify an explicit author using the standard `A U Thor <author@example.com>` format.
 
 
 

--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -527,8 +527,8 @@ is only useful for --non-ff commits.
 `--abort`: Abort the current conflict resolution process, and try to
 reconstruct the pre-merge state.
 
-`--author`: Specify an explicit author using the standard "A U Thor
-author@example.com" format.
+`--author`: Specify an explicit author using the standard `A U Thor
+<author@example.com>` format.
 
 When merging a branch, your session state must be clean. `COMMIT`
 or`ROLLBACK` any changes, then `DOLT_COMMIT()` to create a new dolt

--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -510,7 +510,7 @@ message if not defined.
 
 ```sql
 CALL DOLT_MERGE('feature-branch'); -- Optional --squash parameter
-CALL DOLT_MERGE('feature-branch', '-no-ff', '-m', 'This is a msg for a non fast forward merge');
+CALL DOLT_MERGE('feature-branch', '--no-ff', '-m', 'This is a msg for a non fast forward merge');
 CALL DOLT_MERGE('--abort');
 ```
 


### PR DESCRIPTION
- Provide consistent usage explanation for `--author` in `dolt merge` and `DOLT_MERGE()`
- Fix typo in `--no-ff` usage for `DOLT_MERGE()`