### PR TITLE
updating docs with new spatial type functions

### DIFF
--- a/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -392,9 +392,9 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_Difference()`                 | ❌         |                                                                       |
 | `ST_Dimension()`                  | ✅         |                                                                       |
 | `ST_Disjoint()`                   | ❌         |                                                                       |
-| `ST_Distance()`                   | ❌         |                                                                       |
+| `ST_Distance()`                   | ✅         | Geodetic not yet supported                                            |
 | `ST_Distance_Sphere()`            | ❌         |                                                                       |
-| `ST_EndPoint()`                   | ❌         |                                                                       |
+| `ST_EndPoint()`                   | ✅         |                                                                       |
 | `ST_Envelope()`                   | ❌         |                                                                       |
 | `ST_Equals()`                     | ❌         |                                                                       |
 | `ST_ExteriorRing()`               | ❌         |                                                                       |
@@ -409,7 +409,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_InteriorRingN()`              | ❌         |                                                                       |
 | `ST_Intersection()`               | ❌         |                                                                       |
 | `ST_Intersects()`                 | ❌         |                                                                       |
-| `ST_IsClosed()`                   | ❌         |                                                                       |
+| `ST_IsClosed()`                   | ✅         |                                                                       |
 | `ST_IsEmpty()`                    | ❌         |                                                                       |
 | `ST_IsSimple()`                   | ❌         |                                                                       |
 | `ST_IsValid()`                    | ❌         |                                                                       |
@@ -440,7 +440,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `ST_PolyFromWKB()`                | ✅         |                                                                       |
 | `ST_SRID()`                       | ✅         |                                                                       |
 | `ST_Simplify()`                   | ❌         |                                                                       |
-| `ST_StartPoint()`                 | ❌         |                                                                       |
+| `ST_StartPoint()`                 | ✅         |                                                                       |
 | `ST_SwapXY()`                     | ✅         |                                                                       |
 | `ST_SymDifference()`              | ❌         |                                                                       |
 | `ST_Touches()`                    | ❌         |                                                                       |

--- a/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -54,7 +54,7 @@ title: "Expressions, Functions, and Operators"
 
 ## Functions and operators
 
-**Currently supporting 179 of 438 MySQL functions.**
+**Currently supporting 243 of 438 MySQL functions.**
 
 Most functions are simple to implement. If you need one that isn't implemented, [please file an issue](https://github.com/dolthub/dolt/issues). We can fulfill most requests for new functions within 24 hours.
 


### PR DESCRIPTION
TODO: ~waiting for functions to successfully make it to dolt main~

Marking `st_startpoint`, `st_endpoint`, `st_isclosed`, and `st_distance` as supported.
Updated function support count to be correct.