### PR TITLE
remove force flag from dolt fetch

### DIFF
--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -859,10 +859,7 @@ When no refspec(s) are specified on the command line, the fetch_specs for the de
 
 **Arguments and options**
 
-`-f`, `--force`:
-Update refs to remote branches with the current state of the remote, overwriting any conflicting history.
-
-
+No options for this command.
 
 ## `dolt filter-branch`
 

--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -470,8 +470,7 @@ CALL DOLT_FETCH('origin', 'refs/heads/main:refs/remotes/origin/main');
 
 ### Options
 
-`--force`: Update refs to remote branches with the current state of the
-remote, overwriting any conflicting history
+No options for this procedure.
 
 ### Example
 


### PR DESCRIPTION
removed `--force` option from `dolt fetch` and `DOLT_FETCH()` procedure