### PR TITLE
fix schema for dolt_column_diff

### DIFF
--- a/content/reference/sql/version-control/dolt-system-tables.md
+++ b/content/reference/sql/version-control/dolt-system-tables.md
@@ -780,6 +780,7 @@ The `DOLT_COLUMN_DIFF` system table has the following columns
 | email       | text     |
 | date        | datetime |
 | message     | text     |
+| diff_type   | text     |
 +-------------+----------+
 ```
 


### PR DESCRIPTION
missing `diff_type` column in `dolt_column_diff` schema