### PR TITLE
Update dolt commit options with skip-empty option

### DIFF
--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -441,6 +441,9 @@ Use the given `<msg>` as the commit message.
 `--allow-empty`:
 Allow recording a commit that has the exact same data as its sole parent. This is usually a mistake, so it is disabled by default. This option bypasses that safety.
 
+`--skip-empty`:
+Record a commit only if there are changes to be committed. The commit operation will be a no-op, instead of an error, if there are no changes staged to commit. An error will be thrown if `--skip-empty` is used with `--allow-empty`.
+
 `--date`:
 Specify the date used in the commit. If not specified the current system time is used.
 

--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -503,6 +503,8 @@ CALL DOLT_COMMIT('-m', 'This is a commit', '--author', 'John Doe <johndoe@exampl
 as its sole parent. This is usually a mistake, so it is disabled by
 default. This option bypasses that safety.
 
+`--skip-empty`: Record a commit only if there are changes to be committed. The commit operation will be a no-op, instead of an error, if there are no changes staged to commit. An error will be thrown if `--skip-empty` is used with `--allow-empty`.
+
 `--date`: Specify the date used in the commit. If not specified the
 current system time is used.
 


### PR DESCRIPTION
Dolt PR [#6086](https://github.com/dolthub/dolt/pull/6086) added a new `--skip-empty` option as requested in [issue 5678](https://github.com/dolthub/dolt/issues/5678). Adding this option to the SQL procedure and CLI options.