### PR TITLE
Remove the --aws* flags from dolt_clone and dolt_remote documentation

### DIFF
--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -460,14 +460,6 @@ CALL DOLT_CLONE('dolthub/us-jails', 'myCustomDbName');
 
 `-b`, `--branch`: The branch to be cloned. If not specified all branches will be cloned.
 
-`--aws-region`: The cloud provider region associated with the remote database being cloned.
-
-`--aws-creds-type`: The credential type when cloning a remote database from AWS. Valid options are role, env, and file.
-
-`--aws-creds-file`: The AWS credentials file for use when cloning a remote database from AWS.
-
-`--aws-creds-profile`: The AWS profile name holding the credentials to use when cloning a remote database from AWS.
-
 ### Examples
 
 ```sql
@@ -794,24 +786,14 @@ CALL DOLT_PUSH('origin', 'feature-branch');
 ## `DOLT_REMOTE()`
 
 Adds a remote for a database at given url, or removes an existing remote with its remote-tracking branches
-and configuration settings. Works exactly like [`dolt remote` command](../../cli.md#dolt-remote) on the CLI, and takes
-the same arguments except for listing remotes. To list existing remotes, use the
+and configuration settings. Similar to [`dolt remote` command](../../cli.md#dolt-remote) on the CLI, with the
+exception of cloud provider flags. To list existing remotes, use the
 [`dolt_remotes` system table](./dolt-system-tables.md#dolt_remotes).
 
 ```sql
 CALL DOLT_REMOTE('add','remote_name','remote_url');
 CALL DOLT_REMOTE('remove','existing_remote_name');
 ```
-
-### Options
-
-`--aws-region=<region>`: Specify a cloud provider region associated with this remote.
-
-`--aws-creds-type=<creds-type>`: Specify a credential type. Valid options are role, env, and file.
-
-`--aws-creds-file=<file>`: Specify an AWS credentials file.
-
-`--aws-creds-profile=<profile>`: Specify an AWS profile to use.
 
 ### Example
 


### PR DESCRIPTION
The next dolt build will drop support for these flags:

--aws-region
--aws-creds-type
--aws-creds-file
--aws-creds-profile

https://github.com/dolthub/dolt/pull/6506

I'm working on the assumption that these are not heavily used. This is Aaron's assumption to. If they are actually being used, a customer will come engage us really quickly. The alternative would be to keep these docs here with deprecation statement that they are not supported after 1.10.1. I would rather keep docs clean and not leave something to clean up in the future.