### PR TITLE
CLI command edits

### DIFF
--- a/content/SUMMARY.md
+++ b/content/SUMMARY.md
@@ -122,8 +122,8 @@
 
 ## CLI Reference
 
-- [CLI Command Reference](reference/cli/cli.md)
-- [Supported CLI Commands](reference/cli/supported-commands.md)
+- [Commands](reference/cli/cli.md)
+- [Git Comparison](reference/cli/git-comparison.md)
 
 ## Architecture
 

--- a/content/reference/cli/cli.md
+++ b/content/reference/cli/cli.md
@@ -2,7 +2,7 @@
 title: CLI
 ---
 
-# CLI
+# CLI Commands
 
 ```
 $ dolt

--- a/content/reference/cli/git-comparison.md
+++ b/content/reference/cli/git-comparison.md
@@ -1,16 +1,17 @@
 ---
-title: "Cli Commands"
+title: "Git Comparison"
 ---
 
 We aim to match our CLI command behavior as closely to their Git equivalent as possible. This page lists the commands that are currently supported, and any known limitations.
 
-# Cli Commands
+# Git Comparison
 
 ## Setup and Config
 
-| Component | Supported  | Notes and limitations |
-|:----------|:-----------|:----------------------|
-| `config`  | ✅          |                       |
+| Component | Supported | Notes and limitations |
+|:----------|:----------|:----------------------|
+| `config`  | ✅         |                       |
+| `help`    | 🟠        |                       |
 
 ## Getting and Creating Databases
 
@@ -29,7 +30,8 @@ We aim to match our CLI command behavior as closely to their Git equivalent as p
 | `notes`   | ❌         |                       |
 | `restore` | ❌         |                       |
 | `reset`   | ✅         |                       |
-| `rm`      | ✅         |                       |
+| `rm`      | ❌         |                       |
+| `mv`      | ❌         |                       |
 
 ## Branching and Merging
 
@@ -42,6 +44,7 @@ We aim to match our CLI command behavior as closely to their Git equivalent as p
 | `stash`    | ✅         |                       |
 | `tag`      | ✅         |                       |
 | `worktree` | ❌         |                       |
+| `switch`   | ❌         |                       |
 
 ## Sharing and Updating Databases
 


### PR DESCRIPTION
rename "Supported CLI Commands" to "Git Comparison" and fill in some missing commands