### PR TITLE
remove mentions of dolt sql-client

### DIFF
--- a/content/concepts/dolt/sql/users-grants.md
+++ b/content/concepts/dolt/sql/users-grants.md
@@ -26,25 +26,25 @@ Grants can only apply to traditional SQL access to Dolt tables as of now. Our ro
 
 ### Create a user and grant permissions
 ```
-$ dolt sql-client --user="root"
-# Welcome to the Dolt MySQL client.
+$ dolt sql
+# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
 # "exit" or "quit" (or Ctrl-D) to exit.
-mysql> CREATE USER testuser@localhost IDENTIFIED BY 'password123';
-mysql> GRANT SELECT ON db_name.example TO testuser@localhost;
-mysql> CREATE ROLE testrole;
-mysql> GRANT SELECT, INSERT, UPDATE, DELETE on *.* TO testrole;
-mysql> exit;
+dolt> CREATE USER testuser@localhost IDENTIFIED BY 'password123';
+dolt> GRANT SELECT ON db_name.example TO testuser@localhost;
+dolt> CREATE ROLE testrole;
+dolt> GRANT SELECT, INSERT, UPDATE, DELETE on *.* TO testrole;
+dolt> exit;
 ```
 
 ### Access data as a user
 ```
-$ dolt sql-client --user="testuser" --password="password123"
-# Welcome to the Dolt MySQL client.
+$ dolt --user="testuser" --password="password123" sql
+# Welcome to the DoltSQL shell.
 # Statements must be terminated with ';'.
 # "exit" or "quit" (or Ctrl-D) to exit.
-mysql> USE db_name;
-mysql> SELECT * FROM example;
+dolt> USE db_name;
+db_name> SELECT * FROM example;
 +----+
 | pk |
 +----+
@@ -52,10 +52,10 @@ mysql> SELECT * FROM example;
 | 2  |
 | 3  |
 +----+
-mysql> SELECT * FROM example2;
+db_name> SELECT * FROM example2;
 Error 1105: Access denied for user 'testuser'@'localhost' to table 'example2'
-mysql> SELECT * FROM table_does_not_exist;
+db_name> SELECT * FROM table_does_not_exist;
 Error 1105: Access denied for user 'testuser'@'localhost' to table 'table_does_not_exist'
-mysql> INSERT INTO example VALUES (4);
+db_name> INSERT INTO example VALUES (4);
 Error 1105: command denied to user 'testuser'@'localhost'
 ```

--- a/content/introduction/getting-started/database.md
+++ b/content/introduction/getting-started/database.md
@@ -31,25 +31,9 @@ Your terminal will just hang there. This means the server is running. Any errors
 
 # Connect with any MySQL client
 
-In the new terminal, we will now connect to the running database server using a client. Dolt also ships with a MySQL compatible client. 
+In the new terminal, we will now connect to the running database server using a client.
 
-```bash
-% dolt sql-client -u root
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
-mysql>
-```
-
-In the other terminal where you ran `dolt sql-server`, you'll see the following log line.
-
-```
-2022-06-06T13:14:32-07:00 INFO [conn 1] NewConnection {DisableClientMultiStatements=false}
-```
-
-You are connected!
-
-While we're here let's grab a copy of MySQL so we can connect with that client. Head over to the [MySQL Getting Started](https://dev.mysql.com/doc/mysql-getting-started/en/) documentation and install MySQL on your machine. I used [Homebrew](https://brew.sh/) to install MySQL on my Mac.
+Let's grab a copy of MySQL so we can connect with that client. Head over to the [MySQL Getting Started](https://dev.mysql.com/doc/mysql-getting-started/en/) documentation and install MySQL on your machine. I used [Homebrew](https://brew.sh/) to install MySQL on my Mac.
 
 MySQL comes with a MySQL server called `mysqld` and a MySQL client called `mysql`. You're only interested in the client. After following the instructions from MySQL's documentation, make sure you have a copy of the `mysql` client on your path:
 
@@ -76,14 +60,13 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 
 mysql>
 ```
-
-Again, to ensure the client actually connected, you should see the following in the `dolt sql-server` terminal
+To ensure the client actually connected, you should see the following in the `dolt sql-server` terminal
 
 ```
 2022-06-06T13:26:55-07:00 INFO [conn 2] NewConnection {DisableClientMultiStatements=false}
 ```
 
-As you can see, Dolt supports any MySQL-compatible client. Dolt ships with a client but you can use any MySQL client, like the one that comes with MySQL.
+As you can see, Dolt supports any MySQL-compatible client.
 
 # Create a schema
 

--- a/content/introduction/getting-started/git-for-data.md
+++ b/content/introduction/getting-started/git-for-data.md
@@ -20,7 +20,6 @@ Valid commands for dolt are
               commit - Record changes to the repository.
                  sql - Run a SQL query against tables in repository.
           sql-server - Start a MySQL-compatible server.
-          sql-client - Starts a built-in MySQL client.
                  log - Show commit logs.
               branch - Create, list, edit, delete branches.
             checkout - Checkout a branch or overwrite a table from HEAD.

--- a/content/reference/cli/cli.md
+++ b/content/reference/cli/cli.md
@@ -17,7 +17,6 @@ Valid commands for dolt are
               commit - Record changes to the repository.
                  sql - Run a SQL query against tables in repository.
           sql-server - Start a MySQL-compatible server.
-          sql-client - Starts a built-in MySQL client.
                  log - Show commit logs.
                 show - Show information about a specific commit.
               branch - Create, list, edit, delete branches.
@@ -1893,108 +1892,6 @@ Continue running queries on an error. Used for batch mode only.
 
 `-f`, `--file`:
 Execute statements from the file given.
-
-
-
-## `dolt sql-client`
-
-Starts a built-in MySQL client.
-
-**Synopsis**
-
-```bash
-dolt sql-client [-d] --config <file>
-dolt sql-client [-d] [-H <host>] [-P <port>] [-u <user>] [-p <password>] [-t <timeout>] [-l <loglevel>] [--data-dir <directory>] [--query-parallelism <num-go-routines>] [-r]
-dolt sql-client -q <string> [--use-db <db_name>] [--result-format <format>] [-H <host>] [-P <port>] [-u <user>] [-p <password>]
-```
-
-**Description**
-
-Starts a MySQL client that is built into dolt. May connect to any database that supports MySQL connections, including dolt servers.
-
-You may also start a dolt server and automatically connect to it using this client. Both the server and client will be a part of the same process. This is useful for testing behavior of the dolt server without the need for an external client, and is not recommended for general usage.
-
-Similar to `dolt sql-server`, this command may use a YAML configuration file or command line arguments. For more information on the YAML file, refer to the documentation on `dolt sql-server`.
-
-**Arguments and options**
-
-`--config`:
-When provided configuration is taken from the yaml config file and all command line parameters are ignored.
-
-`-H`, `--host`:
-Defines the host address that the server will run on. Defaults to `localhost`.
-
-`-P`, `--port`:
-Defines the port that the server will run on. Defaults to `3306`.
-
-`-u`, `--user`:
-Defines the server user. Defaults to ``. This should be explicit if desired.
-
-`-p`, `--password`:
-Defines the server password. Defaults to ``.
-
-`-t`, `--timeout`:
-Defines the timeout, in seconds, used for connections
-A value of `0` represents an infinite timeout. Defaults to `28800000`.
-
-`-r`, `--readonly`:
-Disable modification of the database.
-
-`-l`, `--loglevel`:
-Defines the level of logging provided
-Options are: `trace`, `debug`, `info`, `warning`, `error`, `fatal`. Defaults to `info`.
-
-`--data-dir`:
-Defines a directory to find databases to serve. Defaults to the current directory.
-
-`--multi-db-dir`:
-Deprecated, use `--data-dir` instead.
-
-`--doltcfg-dir`:
-Defines a directory that contains non-database storage for dolt. Defaults to `$data-dir/.doltcfg`. Will be created automatically as needed.
-
-`--no-auto-commit`:
-Set @@autocommit = off for the server.
-
-`--query-parallelism`:
-Deprecated, no effect in current versions of Dolt
-
-`--max-connections`:
-Set the number of connections handled by the server. Defaults to `100`.
-
-`--persistence-behavior`:
-Indicate whether to `load` or `ignore` persisted global variables. Defaults to `load`.
-
-`--privilege-file`:
-Path to a file to load and store users and grants. Defaults to `$doltcfg-dir/privileges.db`. Will be created as needed.
-
-`--branch-control-file`:
-Path to a file to load and store branch control permissions. Defaults to `$doltcfg-dir/branch_control.db`. Will be created as needed.
-
-`--allow-cleartext-passwords`:
-Allows use of cleartext passwords. Defaults to false.
-
-`--socket`:
-Path for the unix socket file. Defaults to '/tmp/mysql.sock'.
-
-`--remotesapi-port`:
-Sets the port for a server which can expose the databases in this sql-server over remotesapi, so that clients can clone or pull from this server.
-
-`--golden`:
-Provides a connection string to a MySQL instance to be used to validate query results
-
-`-d`, `--dual`:
-Causes this command to spawn a dolt server that is automatically connected to.
-
-`-q`, `--query`:
-Sends the given query to the server and immediately exits.
-
-`--use-db`:
-Selects the given database before executing a query. By default, uses the current folder's name. Must be used with the --query flag.
-
-`--result-format`:
-Returns the results in the given format. Must be used with the --query flag.
-
 
 
 ## `dolt sql-server`

--- a/content/reference/sql/server/access-management.md
+++ b/content/reference/sql/server/access-management.md
@@ -42,8 +42,7 @@ This behavior was chosen so that server should always have at least one user tha
 
 ## Editing Users
 
-Dolt comes with a MySQL client built-in, which is the [`sql-client`](../../cli/cli.md#dolt-sql-client) command.
-In addition to allowing access to a running server, the client command also has the `--dual` flag which runs a server in the background, while the foreground automatically connects to the background server using the given port, etc.
+Dolt comes with a client built-in, which is the [`sql`](../../cli/cli.md#dolt-sql) command.
 
 Importantly, as described in the [previous section](#user-and-password-arguments), if a non-empty privilege file is provided, then the `--user` and `--password` arguments (also available via a [YAML configuration file](./configuration.md)) _only_ function as login credentials.
 Otherwise, the arguments handle both the creation of a super account **and** login credentials.

--- a/content/reference/sql/server/branch-permissions.md
+++ b/content/reference/sql/server/branch-permissions.md
@@ -173,8 +173,7 @@ The following examples are a small snippet that shows branch permissions in acti
 It is assumed that this document has been read in full, as concepts that are explained in previous sections are not explained in-depth.
 The [setup section](#setup) is run before each example, therefore remember to have a dedicated terminal window for [setup](#setup) if you want to try any of these examples yourself.
 All examples other than [setup](#setup) will exclusively use the second terminal window.
-In addition, all examples will use Dolt's built-in client, accessible using `dolt sql-client`.
-It is not required to use that client, as it is just a standard MySQL client.
+All examples will use MySQL's default client, `mysql`.
 Feel free to use your desired MySQL client.
 
 ### Setup
@@ -184,7 +183,6 @@ As we are running these examples locally, we will use two terminal windows.
 The first window will contain the server, which we are starting here.
 It is worth noting that the examples use the default host and port of `localhost:3306`.
 If these are already in use for your system, then you may supply the arguments `--host="<your_host_here>"` and `--port=<your_port_here>` to change them.
-`dolt sql-client` also takes these same arguments.
 
 As explained in the [default state section](#default-state), we automatically add a row to the `dolt_branch_control` table that allows all users to modify all branches by default.
 For these examples, we remove that default row.
@@ -226,20 +224,14 @@ This example shows the `write` permission in action.
 We add the `write` permission to the `testuser` user, which allows that user to modify the contents of our `main` (default) branch, while the `root` user does not have the permission and cannot make any modifications.
 
 ```
-$ dolt sql-client --user=root
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=root
 mysql> USE example;
 mysql> INSERT INTO dolt_branch_control VALUES ('%', 'main', 'testuser', '%', 'write');
 mysql> CREATE TABLE test (pk BIGINT PRIMARY KEY);
 Error 1105: `root`@`%` does not have the correct permissions on branch `main`
 mysql> exit;
 
-$ dolt sql-client --user=testuser
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=testuser
 mysql> USE example;
 mysql> CREATE TABLE test (pk BIGINT PRIMARY KEY);
 mysql> exit;
@@ -257,10 +249,7 @@ The users added are all fake, and are just used to demonstrate the capability.
 We end by showing that this only applies to the exact match expression, as the very similar `_main` branch name is still off-limits.
 
 ```
-$ dolt sql-client --user=testuser
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=testuser
 mysql> USE example;
 mysql> CREATE TABLE test (pk BIGINT PRIMARY KEY);
 Error 1105: `testuser`@`localhost` does not have the correct permissions on branch `main`
@@ -270,18 +259,12 @@ mysql> INSERT INTO dolt_branch_namespace_control VALUES ('example', 'main', 'new
 Error 1105: `testuser`@`localhost` cannot add the row ["example", "main", "newuser", "%"]
 mysql> exit;
 
-$ dolt sql-client --user=root
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=root
 mysql> USE example;
 mysql> INSERT INTO dolt_branch_control VALUES ('example', 'main%', 'testuser', '%', 'admin');
 mysql> exit;
 
-$ dolt sql-client --user=testuser
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=testuser
 mysql> USE example;
 mysql> CREATE TABLE test (pk BIGINT PRIMARY KEY);
 mysql> INSERT INTO dolt_branch_control VALUES ('example', 'main', 'newuser', '%', 'write');
@@ -304,10 +287,7 @@ The exception being `mainroot`, which while having `main` as a prefix, it is con
 Consequently, `testuser` cannot use `mainroot` as a prefix, as [the longest match](#longest-match) overrides their `main%` entry.
 
 ```
-$ dolt sql-client --user=root
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=root
 mysql> USE example;
 mysql> INSERT INTO dolt_branch_namespace_control VALUES ('%', 'main%', 'testuser', '%');
 mysql> INSERT INTO dolt_branch_namespace_control VALUES ('%', 'mainroot%', 'root', '%');
@@ -331,10 +311,7 @@ mysql> CALL DOLT_BRANCH('mainroot');
 
 mysql> exit;
 
-$ dolt sql-client --user=testuser
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+$ mysql --user=testuser
 mysql> USE example;
 mysql> CALL DOLT_BRANCH('main1');
 +--------+
@@ -357,10 +334,7 @@ Our pre-existing database is `example`, as Dolt uses the directory's name for it
 Therefore, we create another database named `newdb`, which the user `root` will not have any permissions on.
 
 ```
-dolt sql-client --user=root
-# Welcome to the Dolt MySQL client.
-# Statements must be terminated with ';'.
-# "exit" or "quit" (or Ctrl-D) to exit.
+mysql --user=root
 mysql> USE example;
 mysql> CREATE TABLE test (pk BIGINT PRIMARY KEY);
 Error 1105: `root`@`%` does not have the correct permissions on branch `main`

--- a/content/reference/sql/sql-support/miscellaneous.md
+++ b/content/reference/sql/sql-support/miscellaneous.md
@@ -18,7 +18,7 @@ title: Miscellaneous
 
 ## Client Compatibility
 
-Some MySQL features are client features, not server features. Dolt ships with a client (ie. [`dolt sql`](../../cli/cli.md#dolt-sql) or [`dolt sql-client`](../../cli/cli.md#dolt-sql-client)) and a server ([`dolt sql-server`](../../cli/cli.md#dolt-sql-server)). The Dolt client is not as sophisticated as the `mysql` client. To access these features you can use the `mysql` client that ships with MySQL.
+Some MySQL features are client features, not server features. Dolt ships with a client (ie. [`dolt sql`](../../cli/cli.md#dolt-sql)) and a server ([`dolt sql-server`](../../cli/cli.md#dolt-sql-server)). The Dolt client is not as sophisticated as the `mysql` client. To access these features you can use the `mysql` client that ships with MySQL.
 
 | Feature                         | Supported | Notes and limitations                                                                                    |
 |:--------------------------------|:----------|:---------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Removes mentions of `dolt sql-client` from the docs in preparation for deprecation of this command.