### PR TITLE
Removed X from ORMs

### DIFF
--- a/content/guides/dolt-tested-apps.md
+++ b/content/guides/dolt-tested-apps.md
@@ -12,7 +12,7 @@ Let us know what else you'd like to see tested by sending us [email](mailto:inte
 | ORM | Language | Blog | Sample Code | 
 | --- | ---------| ---- | ----------- |
 | [SQLAlchemy](https://www.sqlalchemy.org/) | Python | [Blog](https://www.dolthub.com/blog/2023-07-12-sql-alchemy-getting-started/) | [Code](https://github.com/timsehn/dolt-sqlalchemy-getting-started/tree/main) |
-| [Django](https://www.djangoproject.com/)| Python | [Blog](https://www.dolthub.com/blog/2021-06-09-running-django-on-dolt/) | :x: |
+| [Django](https://www.djangoproject.com/)| Python | [Blog](https://www.dolthub.com/blog/2021-06-09-running-django-on-dolt/) | - |
 | [Hibernate ](https://hibernate.org/)| Java | [Blog](https://www.dolthub.com/blog/2023-11-13-dolt-on-hibernate/) | [Code](https://github.com/dolthub/hibernate-sample) |
 | [Knex.js](https://knexjs.org/) | Javascript | [Blog](https://www.dolthub.com/blog/2023-09-27-dolt-and-knexjs/) | [Code](https://github.com/dolthub/dolt-knexjs-example) |
 | [EF Core](https://learn.microsoft.com/en-us/ef/core/) | C# | [Blog](https://www.dolthub.com/blog/2023-12-04-works-with-dolt-efcore/) | [Code](https://github.com/dolthub/efcore-sample) |


### PR DESCRIPTION
Upon loading the page, when I see a bright red X, my first thought is that something is not supported. Instead, it's just that we don't have the accompanying code sample. I think we should switch this to a dash, which will indicate the same thing, but doesn't have that immediate "something isn't supported" thought. We all know people like to glance at pages.