### PR TITLE
updating correctness

### DIFF
--- a/content/reference/sql/benchmarks/correctness.md
+++ b/content/reference/sql/benchmarks/correctness.md
@@ -77,7 +77,7 @@ supported by Dolt.
 Here are Dolt's function coverage results for version `1.35.0`.
 | Supported | Total | Percent Coverage |
 |-----------|-------|------------------|
-|       263 |   438 |               60 |
+|       298 |   438 |               68 |
 
 ## Skipped Engine Tests
 Here are the total number of tests skipped by the engine for 
@@ -92,4 +92,4 @@ Additionally, these tests are unique and do not overlap in coverage
 
 | Passing | Total | Percent Passing |
 |---------|-------|-----------------|
-|   41383 | 41549 |           99.60 |
+|   41514 | 41674 |           99.62 |

--- a/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -54,7 +54,7 @@ title: "Expressions, Functions, and Operators"
 
 ## Functions and operators
 
-**Currently supporting 263 of 438 MySQL functions.**
+**Currently supporting 298 of 438 MySQL functions.**
 
 Most functions are simple to implement. If you need one that isn't implemented, [please file an issue](https://github.com/dolthub/dolt/issues). We can fulfill most requests for new functions within 24 hours.
 
@@ -82,7 +82,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `^`                               | ✅            |                                                                                                                                               |
 | `ABS()`                           | ✅            |                                                                                                                                               |
 | `ACOS()`                          | ✅            |                                                                                                                                               |
-| `ADDDATE()`                       | ❌            | Use `DATE_ADD()` as a workaround                                                                                                              |
+| `ADDDATE()`                       | ✅            |                                                                                                                                               |
 | `ADDTIME()`                       | ❌            |                                                                                                                                               |
 | `AES_DECRYPT()`                   | ❌            |                                                                                                                                               |
 | `AES_ENCRYPT()`                   | ❌            |                                                                                                                                               |
@@ -226,7 +226,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `JSON_ARRAY_INSERT()`             | ✅            |                                                                                                                                               |
 | `JSON_CONTAINS()`                 | ✅            |                                                                                                                                               |
 | `JSON_CONTAINS_PATH()`            | ✅            |                                                                                                                                               |
-| `JSON_DEPTH()`                    | ❌            |                                                                                                                                               |
+| `JSON_DEPTH()`                    | ✅            |                                                                                                                                               |
 | `JSON_EXTRACT()`                  | ✅            |                                                                                                                                               |
 | `JSON_INSERT()`                   | ✅            |                                                                                                                                               |
 | `JSON_KEYS()`                     | ✅            |                                                                                                                                               |
@@ -248,7 +248,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `JSON_STORAGE_FREE()`             | ❌            |                                                                                                                                               |
 | `JSON_STORAGE_SIZE()`             | ❌            |                                                                                                                                               |
 | `JSON_TABLE()`                    | ✅            | `FOR ORDINALITY` and `NESTED` are not supported yet.                                                                                          |
-| `JSON_TYPE()`                     | ❌            |                                                                                                                                               |
+| `JSON_TYPE()`                     | ✅            | Inconsistencies when using MySQL Native Types                                                                                                 |
 | `JSON_UNQUOTE()`                  | ✅            |                                                                                                                                               |
 | `JSON_VALID()`                    | ✅            |                                                                                                                                               |
 | `JSON_VALUE()`                    | ✅            |                                                                                                                                               |


### PR DESCRIPTION
Added support for:
 - `JSON_DEPTH()`
 - `JSON_TYPE()`
 - `ADDTIME()`

We were miscounting suported functions again.

Various updates to skipped tests and total tests because we keep adding them.