### PR TITLE
Update `dolt_verify_constraints()` stored procedure to support all constraint types

### DIFF
--- a/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -1400,8 +1400,7 @@ SELECT * FROM database1.t;
 ## `DOLT_VERIFY_CONSTRAINTS()`
 
 Verifies that working set changes (inserts, updates, and/or deletes) satisfy the
-defined table constraints. Currently, the command only verifies foreign key
-constraints. If any constraints are violated they are written to the
+defined table constraints. If any constraints are violated they are written to the
 [DOLT_CONSTRAINT_VIOLATIONS](./dolt-system-tables.md#doltconstraintviolations) table.
 
 `DOLT_VERIFY_CONSTRAINTS` by default does not detect constraints for row changes
@@ -1425,11 +1424,11 @@ system table.
 ### Output Schema
 
 ```text
-+------------+------+----------------------+
-| Field      | Type | Description          |
-+------------+------+----------------------+
-| violations | int  | number of violations |
-+------------+------+----------------------+
++------------+------+-----------------------------------------+
+| Field      | Type | Description                             |
++------------+------+-----------------------------------------+
+| violations | int  | 1 if violations were found, otherwise 0 |
++------------+------+-----------------------------------------+
 ```
 
 ### Example


### PR DESCRIPTION
Removing the wording that says only FK constraints are supported. 

Also updated the result description – the docs stated we returned a count of the violations, but the code was actually just returning `0` for no violations and `1` for violations. This would be nice to fix so that we return the actual violation count, but I think we should look at migrating `dolt constraints verify` to the stored procedure first, since it will likely require other result changes, and then we can batch them together in one minor version update. 

Related to: https://github.com/dolthub/dolt/pull/7679