### PR TITLE
removing internal functions

### DIFF
--- a/packages/dolt/content/reference/sql/benchmarks/correctness.md
+++ b/packages/dolt/content/reference/sql/benchmarks/correctness.md
@@ -74,14 +74,14 @@ We also measure the coverage of the functions in the SQL engine. This
 is a measure of how many of the supported MySQL functions are also
 supported by Dolt. 
 
-Here are Dolt's function coverage results for version `1.40.3`.
+Here are Dolt's function coverage results for version `1.42.5`.
 | Supported | Total | Percent Coverage |
 |-----------|-------|------------------|
-|       308 |   438 |               70 |
+|       308 |   431 |               71 |
 
 ## Skipped Engine Tests
 Here are the total number of tests skipped by the engine for 
-version `1.40.3`. These are edge cases that we know are failing for 
+version `1.42.5`. These are edge cases that we know are failing for 
 one reason or another, but haven't been able to fix yet.
 
 In general, these tests are more difficult to fix compared to 
@@ -92,4 +92,4 @@ Additionally, these tests are unique and do not overlap in coverage
 
 | Passing | Total | Percent Passing |
 |---------|-------|-----------------|
-|   43360 | 43578 |           99.50 |
+|   43607 | 43825 |           99.50 |

--- a/packages/dolt/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/packages/dolt/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -54,7 +54,7 @@ title: "Expressions, Functions, and Operators"
 
 ## Functions and operators
 
-**Currently supporting 308 of 438 MySQL functions.**
+**Currently supporting 308 of 431 MySQL functions.**
 
 Most functions are simple to implement. If you need one that isn't implemented, [please file an issue](https://github.com/dolthub/dolt/issues). We can fulfill most requests for new functions within 24 hours.
 
@@ -108,10 +108,6 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `BIT_LENGTH()`                    | ✅            |                                                                                                                                               |
 | `BIT_OR()`                        | ✅            | `\` is supported                                                                                                                              |
 | `BIT_XOR()`                       | ✅            | `^` is supported                                                                                                                              |
-| `CAN_ACCESS_COLUMN()`             | ❌            |                                                                                                                                               |
-| `CAN_ACCESS_DATABASE()`           | ❌            |                                                                                                                                               |
-| `CAN_ACCESS_TABLE()`              | ❌            |                                                                                                                                               |
-| `CAN_ACCESS_VIEW()`               | ❌            |                                                                                                                                               |
 | `CASE`                            | ✅            |                                                                                                                                               |
 | `CAST()`                          | ✅            | Convert between types supported. Convert between charsets is not.                                                                             |
 | `CEIL()`                          | ✅            |                                                                                                                                               |
@@ -181,9 +177,6 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `FROM_BASE64()`                   | ✅            |                                                                                                                                               |
 | `FROM_DAYS()`                     | ✅            |                                                                                                                                               |
 | `FROM_UNIXTIME()`                 | ✅            |                                                                                                                                               |
-| `GET_DD_COLUMN_PRIVILEGES()`      | ❌            |                                                                                                                                               |
-| `GET_DD_CREATE_OPTIONS()`         | ❌            |                                                                                                                                               |
-| `GET_DD_INDEX_SUB_PART_LENGTH()`  | ❌            |                                                                                                                                               |
 | `GET_FORMAT()`                    | ❌            |                                                                                                                                               |
 | `GET_LOCK()`                      | ✅            |                                                                                                                                               |
 | `GREATEST()`                      | ✅            |                                                                                                                                               |

--- a/packages/doltgres/content/reference/sql/version-control/dolt-sql-procedures.md
+++ b/packages/doltgres/content/reference/sql/version-control/dolt-sql-procedures.md
@@ -729,7 +729,6 @@ CALL DOLT_MERGE('origin/main');
 ```
 
 ### Notes
-
 Dropping the second argument, or passing NULL, will result is using the default refspec.
 
 ## `DOLT_GC()`


### PR DESCRIPTION
This PR removes 4 functions that are MySQL Internal functions that always return error when used.
https://dev.mysql.com/doc/refman/8.4/en/internal-functions.html

Also, updates our correctness metrics.