### PR TITLE
Add more supported SQL functions to the list

### DIFF
--- a/packages/dolt/content/reference/sql/sql-support/expressions-functions-operators.md
+++ b/packages/dolt/content/reference/sql/sql-support/expressions-functions-operators.md
@@ -54,7 +54,7 @@ title: "Expressions, Functions, and Operators"
 
 ## Functions and operators
 
-**Currently supporting 324 of 431 MySQL functions.**
+**Currently supporting 326 of 431 MySQL functions.**
 
 Most functions are simple to implement. If you need one that isn't implemented, [please file an issue](https://github.com/dolthub/dolt/issues). We can fulfill most requests for new functions within 24 hours.
 
@@ -333,7 +333,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `REGEXP_LIKE()`                   | ✅            |                                                                                                                                               |
 | `REGEXP_MATCHES()`                | ❌            |                                                                                                                                               |
 | `REGEXP_REPLACE()`                | ✅            |                                                                                                                                               |
-| `REGEXP_SUBSTR()`                 | ❌            |                                                                                                                                               |
+| `REGEXP_SUBSTR()`                 | ✅            |                                                                                                                                               |
 | `REGEXP`                          | ✅            |                                                                                                                                               |
 | `RELEASE_ALL_LOCKS()`             | ✅            |                                                                                                                                               |
 | `RELEASE_LOCK()`                  | ✅            |                                                                                                                                               |
@@ -456,7 +456,7 @@ Most functions are simple to implement. If you need one that isn't implemented, 
 | `TIMEDIFF()`                      | ✅            |                                                                                                                                               |
 | `TIMESTAMP()`                     | ✅            |                                                                                                                                               |
 | `TIMESTAMPADD()`                  | ❌            |                                                                                                                                               |
-| `TIMESTAMPDIFF()`                 | ❌            |                                                                                                                                               |
+| `TIMESTAMPDIFF()`                 | ✅            |                                                                                                                                               |
 | `TIME_FORMAT()`                   | ✅            |                                                                                                                                               |
 | `TIME_TO_SEC()`                   | ✅            |                                                                                                                                               |
 | `TO_BASE64()`                     | ✅            |                                                                                                                                               |


### PR DESCRIPTION
I tested these locally and found that they worked for me, at least with simple queries:

```sql
SELECT
  TIMESTAMPDIFF(HOUR, '2023-01-01', '2023-01-02') as timestampdiff_val,
  REGEXP_SUBSTR('hello world', 'world') as regexp_substr_val
```

So I figured I should update them here